### PR TITLE
Improve Google credentials error handling

### DIFF
--- a/src/lib/google-sheets.ts
+++ b/src/lib/google-sheets.ts
@@ -24,8 +24,18 @@ function getGoogleSheetsClient() {
     throw new Error('GOOGLE_SERVICE_ACCOUNT_CREDENTIALS environment variable is not set');
   }
 
+  let parsedCredentials;
+  try {
+    parsedCredentials = JSON.parse(credentials);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse GOOGLE_SERVICE_ACCOUNT_CREDENTIALS. ` +
+      `Ensure it contains valid JSON. Error: ${(error as Error).message}`
+    );
+  }
+
   const auth = new google.auth.GoogleAuth({
-    credentials: JSON.parse(credentials),
+    credentials: parsedCredentials,
     scopes: ['https://www.googleapis.com/auth/spreadsheets'],
   });
 


### PR DESCRIPTION
Add try-catch block around JSON.parse() for GOOGLE_SERVICE_ACCOUNT_CREDENTIALS to provide clearer error messages when credentials are malformed.

Fixes #5