### PR TITLE
feat: add health check endpoint for container monitoring

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic' // Disable caching
+
+export async function GET() {
+  try {
+    // Check database connectivity
+    await prisma.$queryRaw`SELECT 1`
+
+    // Check Google Sheets configuration
+    const sheetsConfigured = !!(
+      process.env.GOOGLE_SHEETS_SPREADSHEET_ID &&
+      process.env.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS
+    )
+
+    return NextResponse.json({
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      version: '1.0.0',
+      services: {
+        database: 'connected',
+        googleSheets: sheetsConfigured ? 'configured' : 'missing',
+      },
+    })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        status: 'unhealthy',
+        timestamp: new Date().toISOString(),
+        error: 'Database connection failed',
+      },
+      { status: 503 }
+    )
+  }
+}


### PR DESCRIPTION
Creates /api/health endpoint that checks:
- Database connectivity via Prisma
- Google Sheets configuration
- Returns service status and version

This enables Docker health checks and external monitoring.

Closes #7 

🤖 Generated with [Claude Code](https://claude.com/claude-code)